### PR TITLE
Add registered tuple app file to placate systools

### DIFF
--- a/src/uuid.app.src
+++ b/src/uuid.app.src
@@ -2,6 +2,7 @@
   [{description, "Native UUID Generation"},
    {vsn, "0.1.4"},
    {modules, [uuid]},
+   {registered, []},
    {applications, [crypto, stdlib]},
    {start_phases, []}]}.
 


### PR DESCRIPTION
Add registered tuple to uuid.app.src to prevent systools from crashing when packaging upgrades for apps that depend on uuid
