### PR TITLE
Add kernel to dependencies

### DIFF
--- a/src/uuid.app.src
+++ b/src/uuid.app.src
@@ -3,5 +3,5 @@
    {vsn, "1.3.1"},
    {modules, [uuid]},
    {registered, []},
-   {applications, [quickrand, stdlib]}]}.
+   {applications, [kernel, quickrand, stdlib]}]}.
 


### PR DESCRIPTION
This is to prevent some lock-up problems when using init:stop to bring down a node.
