### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ bitwise-XORed from 72 bits down to 32 bits.
 The version 3 (MD5), version 4 (random), and version 5 (SHA)
 methods are provided as specified within the RFC.
 
-Requires `Erlang >= R14B01`
+Requires `Erlang >= R16B01`
 
 Build
 -----


### PR DESCRIPTION
Fix required Erlang version from >= R14B01 to >= R16B01, since it became incorrect after the following commit to master:
https://github.com/okeuday/uuid/commit/4a6b95b1412d2da7cf33be64e74d2b821123c040
