### PR TITLE
updated dependency configuration to the latest erlang.mk format to ge…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = uuid
 
 DEPS = quickrand
-dep_quickrand = https://github.com/okeuday/quickrand
+dep_quickrand = git https://github.com/okeuday/quickrand master
 
 include erlang.mk


### PR DESCRIPTION
…t rid of warning during build:

../../erlang.mk:4645: WARNING: 'quickrand' dependency configuration uses deprecated format.