### PR TITLE
Allow `rebar3_sbom` (and Hex) to identify license for library

### DIFF
--- a/src/uuid.app.src
+++ b/src/uuid.app.src
@@ -6,5 +6,6 @@
    {vsn, "2.0.7"},
    {modules, [uuid]},
    {registered, []},
-   {applications, [quickrand, stdlib, kernel]}]}.
+   {applications, [quickrand, stdlib, kernel]},
+   {licenses, ["MIT"]}]}.
 


### PR DESCRIPTION
Hi.

We're using [rebar3_sbom](https://github.com/voltone/rebar3_sbom) to build a list of dependency licenses so we can later filter on them. This plugin works with the information accessible from the `.app.src` file, as per https://github.com/voltone/rebar3_sbom/issues/16.

This pull request adds to that file as per https://github.com/okeuday/uuid/blob/master/LICENSE.

## Further considerations

I also noticed that `rebar.lock` is not checked in, and `_build` is not `.gitignore`d. Lemme know if you want me to push changes related to this.