### PR TITLE
Fix Elixir compiler warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Uuid.Mixfile do
      version: "2.0.7",
      language: :erlang,
      erlc_options: [
-       {:d, :erlang.list_to_atom('ERLANG_OTP_VERSION_' ++ :erlang.system_info(:otp_release))},
+       {:d, :erlang.list_to_atom(~c"ERLANG_OTP_VERSION_" ++ :erlang.system_info(:otp_release))},
        :deterministic,
        :debug_info,
        :warn_export_vars,


### PR DESCRIPTION
Fix Elixir warning from `mix.exs`:
```
    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 12 │        {:d, :erlang.list_to_atom('ERLANG_OTP_VERSION_' ++ :erlang.system_info(:otp_release))},
    │                                  ~
    │
    └─ mix.exs:12:34
```